### PR TITLE
Add Automatic-Module-Name jar manifest entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,17 @@
 					<version>2.22.1</version>
 				</plugin>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<configuration>
+						<archive>
+							<manifestEntries>
+								<Automatic-Module-Name>com.github.kkuegler.human_readable_ids</Automatic-Module-Name>
+							</manifestEntries>
+						</archive>
+					</configuration>
+				</plugin>
+				<plugin>
 					<artifactId>maven-install-plugin</artifactId>
 					<version>2.5.2</version>
 				</plugin>


### PR DESCRIPTION
This PR adds a the `Automatic-Module-Name` manifest entry, making it easier for modular projects (Java 9 and above) to include this library. I've given the name `com.github.kkuegler.human_readable_ids` to the module, this can of course be changed if desired.
