### PR TITLE
Add configuration for the Graal native image compiler for text file resources

### DIFF
--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "adjectives.txt"
+      },
+      {
+        "pattern": "animals.txt"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
When compiling an app using the Graal VM, any resources loaded by name won't exist in the final image.

This PR includes a configuration file so that the resource files (animals.txt and adjectives.txt) are available in the final native image without any work needed by the consumer of this library.

See https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Resources/ for details on the configuration format of resource-config.json.